### PR TITLE
Fix for quotes bug with editing dialog prompts

### DIFF
--- a/scripts/views/dialog_option_editor.js
+++ b/scripts/views/dialog_option_editor.js
@@ -80,6 +80,21 @@ function(
         },
         link_types: self.link_types,
 
+        //Function that will escape special characters like quotes.
+        //Specifically for rendering in the web view for editing a prompt
+        escaped_prompt:  function(text) {
+        	  var characters = {
+        	    '&': '&amp;',
+        	    '"': '&quot;',
+        	    "'": '&#039;',
+        	    '<': '&lt;',
+        	    '>': '&gt;'
+        	  };
+        	  return (text + "").replace(/[<>&"']/g, function(m){
+        	    return characters[m];
+        	  });
+        	},
+        	
         scripts: self.scripts,
         speakerfromscriptid: function(id)
         {

--- a/templates/dialog_option_editor.tpl
+++ b/templates/dialog_option_editor.tpl
@@ -12,7 +12,7 @@
 
 <div class="form-group">
 	<label>Prompt</label>
-	<input autofocus type="text" class="form-control prompt" value="<%= prompt %>">
+	<input autofocus type="text" class="form-control prompt" value="<%= escaped_prompt(prompt) %>">
 </div>
 
 <div class="form-group">


### PR DESCRIPTION
- Fix for quotes bug with editing dialog prompts that have double or single quotes in the string.
- Escapes specicial characters for rendering in webview when editing a
  dialog prompt.
