### PR TITLE
Removing strip_js() from prompt field

### DIFF
--- a/templates/dialog_option_editor.tpl
+++ b/templates/dialog_option_editor.tpl
@@ -12,7 +12,7 @@
 
 <div class="form-group">
   <label>Prompt</label>
-  <input autofocus type="text" class="form-control prompt" value="<%= escaped_prompt(strip_js(prompt)) %>">
+  <input autofocus type="text" class="form-control prompt" value="<%= escaped_prompt(prompt) %>">
 </div>
 
 <div class="form-group">


### PR DESCRIPTION
- removing call to strip_js for the text for the prompt field.  There shouldn't be any javascript in the prompt fields anyways.  Was causing an issue with saving HTML in the prompt field.
